### PR TITLE
feat: add Docker Compose support for installation and database import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 secrets
 uptimelabs.sql
 dist/
+upctl

--- a/cmd/dockerComposeCmd.go
+++ b/cmd/dockerComposeCmd.go
@@ -1,0 +1,385 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// DockerComposeConfig is the struct that holds the Docker Compose config values
+type DockerComposeConfig struct {
+	Version  string                 `mapstructure:"version" yaml:"version"`
+	Services map[string]interface{} `mapstructure:"services" yaml:"services"`
+	Volumes  map[string]interface{} `mapstructure:"volumes" yaml:"volumes,omitempty"`
+	Networks map[string]interface{} `mapstructure:"networks" yaml:"networks,omitempty"`
+}
+
+var (
+	dockerComposeConfig DockerComposeConfig
+	dockerComposeCmd    = &cobra.Command{
+		Use:   "docker",
+		Short: "Docker compose commands",
+		Long:  `Commands for managing Docker Compose environment`,
+	}
+
+	dockerComposeUpCmd = &cobra.Command{
+		Use:   "up [service]",
+		Short: "Start Docker Compose services",
+		Long:  `Start Docker Compose services defined in the configuration`,
+		Args:  cobra.MaximumNArgs(1),
+		Run:   runDockerComposeUp,
+	}
+
+	dockerComposeDownCmd = &cobra.Command{
+		Use:   "down",
+		Short: "Stop Docker Compose services",
+		Long:  `Stop Docker Compose services defined in the configuration`,
+		Run:   runDockerComposeDown,
+	}
+
+	dockerComposeListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List Docker Compose services",
+		Long:  `List Docker Compose services defined in the configuration`,
+		Run:   runDockerComposeList,
+	}
+
+	dockerComposeInstallCmd = &cobra.Command{
+		Use:   "install [service]",
+		Short: "Install and start a specific service",
+		Long:  `Install and start a specific service from the configuration`,
+		Args:  cobra.MaximumNArgs(1),
+		Run:   runDockerComposeInstall,
+	}
+
+	dockerComposeLogs = &cobra.Command{
+		Use:   "logs [service]",
+		Short: "Show logs for services",
+		Long:  `Show logs for Docker Compose services defined in the configuration`,
+		Args:  cobra.MaximumNArgs(1),
+		Run:   runDockerComposeLogs,
+	}
+
+	dockerComposeImportDBCmd = &cobra.Command{
+		Use:   "import-db",
+		Short: "Import a database",
+		Long:  `Import a database into a Docker MySQL container`,
+		Run:   runDockerImportDB,
+	}
+)
+
+func init() {
+	dockerComposeCmd.AddCommand(
+		dockerComposeUpCmd,
+		dockerComposeDownCmd,
+		dockerComposeListCmd,
+		dockerComposeInstallCmd,
+		dockerComposeLogs,
+		dockerComposeImportDBCmd,
+	)
+
+	// Add the "all" flag to the install command for installing all services
+	dockerComposeInstallCmd.Flags().BoolP("all", "a", false, "Install all services")
+
+	rootCmd.AddCommand(dockerComposeCmd)
+}
+
+func runDockerComposeUp(cmd *cobra.Command, args []string) {
+	progress.Start()
+	defer progress.Stop()
+
+	// Create a temporary compose file
+	tempComposePath, err := createTempComposeFile()
+	if err != nil {
+		fmt.Printf("Error creating temporary compose file: %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer os.Remove(tempComposePath)
+
+	// Start docker compose
+	fmt.Println("Starting Docker Compose services...")
+
+	var composeArgs []string
+	composeArgs = append(composeArgs, "compose", "-f", tempComposePath, "up", "-d")
+
+	// If a specific service is specified
+	if len(args) > 0 {
+		composeArgs = append(composeArgs, args[0])
+	}
+
+	err = ExecuteCommand("docker", composeArgs...)
+	if err != nil {
+		fmt.Printf("Error starting Docker Compose services: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Println("Docker Compose services started successfully")
+}
+
+func runDockerComposeDown(cmd *cobra.Command, args []string) {
+	progress.Start()
+	defer progress.Stop()
+
+	// Create a temporary compose file
+	tempComposePath, err := createTempComposeFile()
+	if err != nil {
+		fmt.Printf("Error creating temporary compose file: %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer os.Remove(tempComposePath)
+
+	// Stop docker compose
+	fmt.Println("Stopping Docker Compose services...")
+	err = ExecuteCommand("docker", "compose", "-f", tempComposePath, "down")
+	if err != nil {
+		fmt.Printf("Error stopping Docker Compose services: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Println("Docker Compose services stopped successfully")
+}
+
+func runDockerComposeList(cmd *cobra.Command, args []string) {
+	// Load docker compose config from viper
+	err := viper.UnmarshalKey("docker_compose", &dockerComposeConfig)
+	if err != nil {
+		fmt.Printf("Error loading docker compose config: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Println("Available Docker Compose services:")
+	for service := range dockerComposeConfig.Services {
+		fmt.Printf("- %s\n", service)
+	}
+}
+
+// runDockerComposeInstall handles the installation of specific or all services
+func runDockerComposeInstall(cmd *cobra.Command, args []string) {
+	progress.Start()
+	defer progress.Stop()
+
+	// Check if "all" flag is set or a specific service is requested
+	installAll, _ := cmd.Flags().GetBool("all")
+
+	if !(len(args) > 0 || installAll) {
+		fmt.Println("Please provide a service name or --all flag")
+		os.Exit(1)
+	}
+
+	// Create a temporary compose file
+	tempComposePath, err := createTempComposeFile()
+	if err != nil {
+		fmt.Printf("Error creating temporary compose file: %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer os.Remove(tempComposePath)
+
+	// Load the services from the config
+	err = viper.UnmarshalKey("docker_compose", &dockerComposeConfig)
+	if err != nil {
+		fmt.Printf("Error loading docker compose config: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	if len(args) > 0 {
+		// Check if the requested service exists
+		serviceName := args[0]
+		if _, exists := dockerComposeConfig.Services[serviceName]; !exists {
+			fmt.Printf("Service '%s' not found in configuration\n", serviceName)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Installing and starting service: %s\n", serviceName)
+		err = ExecuteCommand("docker", "compose", "-f", tempComposePath, "up", "-d", serviceName)
+		if err != nil {
+			fmt.Printf("Error installing service %s: %s\n", serviceName, err.Error())
+			os.Exit(1)
+		}
+		fmt.Printf("Service %s installed and started successfully\n", serviceName)
+	} else if installAll {
+		fmt.Println("Installing and starting all services...")
+		err = ExecuteCommand("docker", "compose", "-f", tempComposePath, "up", "-d")
+		if err != nil {
+			fmt.Printf("Error installing all services: %s\n", err.Error())
+			os.Exit(1)
+		}
+		fmt.Println("All services installed and started successfully")
+	}
+}
+
+// runDockerComposeLogs shows logs for one or all services
+func runDockerComposeLogs(cmd *cobra.Command, args []string) {
+	// Create a temporary compose file
+	tempComposePath, err := createTempComposeFile()
+	if err != nil {
+		fmt.Printf("Error creating temporary compose file: %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer os.Remove(tempComposePath)
+
+	var logArgs []string
+	logArgs = append(logArgs, "compose", "-f", tempComposePath, "logs")
+
+	// If a specific service is specified
+	if len(args) > 0 {
+		logArgs = append(logArgs, args[0])
+	}
+
+	// Show logs with follow option
+	logArgs = append(logArgs, "--follow")
+
+	// Execute the command to show logs
+	err = ExecuteCommand("docker", logArgs...)
+	if err != nil {
+		fmt.Printf("Error showing logs: %s\n", err.Error())
+		os.Exit(1)
+	}
+}
+
+// createTempComposeFile creates a temporary docker-compose.yml file from the config
+// runDockerImportDB handles importing a database into a Docker MySQL container
+func runDockerImportDB(cmd *cobra.Command, args []string) {
+	progress.Start()
+	defer progress.Stop()
+
+	// Create a temporary compose file
+	tempComposePath, err := createTempComposeFile()
+	if err != nil {
+		fmt.Printf("Error creating temporary compose file: %s\n", err.Error())
+		os.Exit(1)
+	}
+	defer os.Remove(tempComposePath)
+
+	// Make sure the MySQL service is running
+	fmt.Println("Ensuring MySQL service is running...")
+	err = ExecuteCommand("docker", "compose", "-f", tempComposePath, "up", "-d", "mysql")
+	if err != nil {
+		fmt.Printf("Error starting MySQL service: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	// Handle database import using docker exec
+	dbFilePath := cleanPath(mysqlConfig.DBFile)
+
+	// If file does not exist, download from s3 bucket
+	if _, err := os.Stat(dbFilePath); os.IsNotExist(err) {
+		// download database from s3 bucket using tsh aws command
+		fmt.Println("Downloading database...")
+
+		// Check for tsh and authenticate if needed
+		path, err := exec.LookPath("tsh")
+		if err != nil {
+			fmt.Println("Error finding tsh:", err)
+			progress.Stop()
+			os.Exit(1)
+		}
+
+		// Authenticate with Teleport if needed
+		fmt.Println("Authenticating with Teleport...")
+		if err := ExecuteCommand(path, "login", fmt.Sprintf("--proxy=%s", teleportConfig.Host)); err != nil {
+			fmt.Println("Error authenticating with Teleport:", err)
+			progress.Stop()
+			os.Exit(2)
+		}
+
+		fmt.Println("Authenticating with AWS...")
+		if err := ExecuteCommand(path, "apps", "login", teleportConfig.AWSApp, "--aws-role", teleportConfig.AWSRole); err != nil {
+			fmt.Println("Error authenticating with AWS:", err)
+			progress.Stop()
+			os.Exit(2)
+		}
+
+		// Download the database file
+		if err := ExecuteCommand("tsh", "aws", "--app", teleportConfig.AWSApp, "s3", "cp",
+			fmt.Sprintf("s3://%s/%s", mysqlConfig.S3Bucket, mysqlConfig.S3Key), dbFilePath,
+			"--region", mysqlConfig.S3Region); err != nil {
+			fmt.Println("Error downloading database:", err)
+			progress.Stop()
+			os.Exit(2)
+		}
+	}
+
+	// Get the container ID
+	fmt.Println("Getting MySQL container ID...")
+	containerIDCmd := exec.Command("docker", "compose", "-f", tempComposePath, "ps", "-q", "mysql")
+	containerIDBytes, err := containerIDCmd.Output()
+	if err != nil {
+		fmt.Printf("Error getting MySQL container ID: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	containerID := strings.TrimSpace(string(containerIDBytes))
+	if containerID == "" {
+		fmt.Println("Error: MySQL container not found")
+		os.Exit(1)
+	}
+
+	// Copy the database file to the container
+	fmt.Println("Copying database file to container...")
+	tmpPath := "/tmp/import.sql"
+	err = ExecuteCommand("docker", "cp", dbFilePath, containerID+":"+tmpPath)
+	if err != nil {
+		fmt.Printf("Error copying database file to container: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	// Import the database
+	fmt.Println("Importing database...")
+	importCmd := fmt.Sprintf("mysql -u %s -p%s %s < %s",
+		mysqlConfig.User, mysqlConfig.Password, mysqlConfig.Database, tmpPath)
+
+	err = ExecuteCommand("docker", "exec", containerID, "bash", "-c", importCmd)
+	if err != nil {
+		fmt.Printf("Error importing database: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	// Clean up
+	fmt.Println("Cleaning up...")
+	err = ExecuteCommand("docker", "exec", containerID, "rm", tmpPath)
+	if err != nil {
+		fmt.Printf("Error cleaning up: %s\n", err.Error())
+	}
+
+	fmt.Println("Database imported successfully")
+}
+
+func createTempComposeFile() (string, error) {
+	// Load docker compose config from viper
+	err := viper.UnmarshalKey("docker_compose", &dockerComposeConfig)
+	if err != nil {
+		return "", fmt.Errorf("error loading docker compose config: %s", err.Error())
+	}
+
+	// Create a temporary file
+	tempFile, err := os.CreateTemp("", "docker-compose-*.yml")
+	if err != nil {
+		return "", fmt.Errorf("error creating temporary file: %s", err.Error())
+	}
+	tempFilePath := tempFile.Name()
+
+	// Marshal the config to YAML
+	yamlData, err := yaml.Marshal(dockerComposeConfig)
+	if err != nil {
+		tempFile.Close()
+		return "", fmt.Errorf("error marshaling config to YAML: %s", err.Error())
+	}
+
+	// Write the YAML to the temporary file
+	if _, err := tempFile.Write(yamlData); err != nil {
+		tempFile.Close()
+		return "", fmt.Errorf("error writing to temporary file: %s", err.Error())
+	}
+
+	// Close the file
+	if err := tempFile.Close(); err != nil {
+		return "", fmt.Errorf("error closing temporary file: %s", err.Error())
+	}
+
+	return tempFilePath, nil
+}

--- a/cmd/importDBCmd.go
+++ b/cmd/importDBCmd.go
@@ -11,7 +11,7 @@ import (
 var importDBCmd = &cobra.Command{
 	Use:   "import-db",
 	Short: "Import a database",
-	Long:  `Import a database using tsh and mysql.`,
+	Long:  `Import a database using tsh and mysql. Use --docker flag to import into a Docker container.`,
 	Args:  cobra.MinimumNArgs(0),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		progress.Start()
@@ -40,6 +40,17 @@ var importDBCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		// Check if docker flag is set
+		useDocker, _ := cmd.Flags().GetBool("docker")
+
+		// If using Docker, delegate to the docker compose import-db command
+		if useDocker {
+			dockerCmd := dockerComposeImportDBCmd
+			dockerCmd.Run(dockerCmd, args)
+			return
+		}
+
+		// Otherwise, continue with traditional import
 		progress.Start()
 		defer progress.Stop()
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -105,6 +105,11 @@ func ExecuteCommand(command string, args ...string) error {
 
 // Create kubernetes clientset
 func createClientSet() (*kubernetes.Clientset, error) {
+	// Check if Kubernetes config is available
+	if restConfig == nil {
+		return nil, fmt.Errorf("kubernetes configuration is not available")
+	}
+
 	overrides := &clientcmd.ConfigOverrides{
 		CurrentContext: kubeContext,
 	}

--- a/upctl.yaml
+++ b/upctl.yaml
@@ -86,3 +86,97 @@ mysql:
   s3_bucket: backups
   s3_key: dump.sql
   s3_region: us-east-1
+
+# docker_compose is the configuration for the Docker Compose functionality
+# It defines the services and configurations to be used with docker-compose
+docker_compose:
+  services:
+    # Loki for log aggregation
+    loki:
+      container_name: upctl_loki
+      image: grafana/loki:latest
+      ports:
+        - "3100:3100"
+      volumes:
+        - upctl_loki-data:/loki
+      command: -config.file=/etc/loki/local-config.yaml
+      restart: unless-stopped
+      networks:
+        - upctl_network
+      environment:
+        - TZ=UTC
+      labels:
+        service: "loki"
+        
+    # Grafana for visualization
+    grafana:
+      container_name: upctl_grafana
+      image: grafana/grafana:latest
+      ports:
+        - "3000:3000"
+      volumes:
+        - upctl_grafana-data:/var/lib/grafana
+      restart: unless-stopped
+      networks:
+        - upctl_network
+      environment:
+        - GF_SECURITY_ADMIN_USER=admin
+        - GF_SECURITY_ADMIN_PASSWORD=admin
+        - GF_USERS_ALLOW_SIGN_UP=false
+        - GF_INSTALL_PLUGINS=grafana-piechart-panel
+      depends_on:
+        - loki
+      labels:
+        service: "grafana"
+        
+    # Prometheus for metrics
+    prometheus:
+      container_name: upctl_prometheus
+      image: prom/prometheus:latest
+      ports:
+        - "9090:9090"
+      volumes:
+        - upctl_prometheus-data:/prometheus
+      restart: unless-stopped
+      networks:
+        - upctl_network
+      command:
+        - --config.file=/etc/prometheus/prometheus.yml
+        - --storage.tsdb.path=/prometheus
+        - --web.console.libraries=/usr/share/prometheus/console_libraries
+        - --web.console.templates=/usr/share/prometheus/consoles
+      labels:
+        service: "prometheus"
+        
+    # MySQL database
+    mysql:
+      container_name: upctl_mysql
+      image: mysql:8.0
+      ports:
+        - "3307:3306"
+      volumes:
+        - upctl_mysql-data:/var/lib/mysql
+      restart: unless-stopped
+      networks:
+        - upctl_network
+      environment:
+        - MYSQL_ROOT_PASSWORD=rootpassword
+        - MYSQL_DATABASE=db
+        - MYSQL_USER=user
+        - MYSQL_PASSWORD=pwd
+      labels:
+        service: "mysql"
+
+  volumes:
+    upctl_loki-data:
+      driver: local
+    upctl_grafana-data:
+      driver: local
+    upctl_prometheus-data:
+      driver: local
+    upctl_mysql-data:
+      driver: local
+
+  networks:
+    upctl_network:
+      driver: bridge


### PR DESCRIPTION
- Enhanced the install command to support Docker Compose
  alongside Helm for package installation.
- Updated README to reflect the new Docker Compose functionality.
- Added a `--docker` flag to both `install` and `import-db`
  commands for specifying the use of Docker Compose.
- Improved documentation with examples for Docker Compose
  configurations and commands.
