### PR TITLE
fix: Specify branch for install.sh update in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
           author_name: GitHub Action
           author_email: action@github.com
           message: 'Update install.sh to version ${{ env.RELEASE_VERSION }}'
+          branch: main # Add this line
           push: true
         env:
           GITHUB_HEAD_REF: ${{ github.ref_name }}


### PR DESCRIPTION
The release workflow was failing because the EndBug/add-and-commit action was trying to commit and push from a detached HEAD state. This occurred because the workflow is triggered by a tag, and actions/checkout checks out the specific commit for the tag.

This commit fixes the issue by explicitly setting the `branch` parameter to `main` in the add-and-commit action, ensuring the commit is made to the main branch.